### PR TITLE
Fixing epsilon naught syntax error

### DIFF
--- a/docs/Epsilon_naught.md
+++ b/docs/Epsilon_naught.md
@@ -9,7 +9,7 @@ The ordinal $\\epsilon\_0$, commonly given the British pronunciation
 $\\alpha=\\omega^\\alpha$ and can be equivalently characterized as the
 supremum
 
-$$\\epsilon\_0=\\sup\\{\\omega,\\omega^\\omega,\\omega^{\\omega^\\omega},\\ldots\\}$$
+$$\\epsilon\_0=\\sup\\{\\omega,\\omega^{\\omega},\\omega^{\\omega^{\\omega}},\\ldots\\}$$
 
 The [ordinals below
 $\\epsilon\_0$](Small_countable_ordinals "Small countable ordinals")


### PR DESCRIPTION
Epsilon naught's page currently displays a syntax error for the first supremum expression, "Missing open brace for superscript". I believe this should fix it, the omega power towers appeared to be missing braces around the topmost exponent compared to the power towers in the supremum expression for the general epsilon-number hierarchy.